### PR TITLE
BAH-4017 | Add. Global Property to Stop Slots When Drug Order is Stopped

### DIFF
--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -16,6 +16,13 @@
 		<require_module>org.bahmni.module.medication-administration</require_module>
 		<require_module>org.bahmni.module.fhir2Extension</require_module>
 	</require_modules>
+
+	<globalProperty>
+		<property>bahmni-ipd.allowSlotStopOnDrugOrderStop</property>
+		<defaultValue>true</defaultValue>
+		<description>Feature toggle to decide whether to stop slots associated when drug order is stopped</description>
+	</globalProperty>
+	
 	<activator>org.openmrs.module.ipd.api.IPDActivator</activator>
 </module>
 


### PR DESCRIPTION
JIRA -> [BAH-4017](https://bahmni.atlassian.net/browse/BAH-4017)

In this PR, the global property bahmni-ipd.allowSlotStopOnDrugOrderStop is added which decides whether to stop slots associated when drug order is stopped. 