### PR TITLE
BAH-4031 | Add. Set flag to mark system generated tasks

### DIFF
--- a/api/src/main/java/org/openmrs/module/ipd/api/events/IPDEventUtils.java
+++ b/api/src/main/java/org/openmrs/module/ipd/api/events/IPDEventUtils.java
@@ -8,7 +8,7 @@ import java.util.Date;
 
 public class IPDEventUtils {
 
-    public static TaskRequest createNonMedicationTaskRequest(IPDEvent ipdEvent, String name, String taskType) {
+    public static TaskRequest createNonMedicationTaskRequest(IPDEvent ipdEvent, String name, String taskType, Boolean isSystemGenerated) {
         TaskRequest taskRequest = new TaskRequest();
         taskRequest.setName(name);
         taskRequest.setTaskType(taskType);
@@ -17,6 +17,7 @@ public class IPDEventUtils {
         taskRequest.setRequestedStartTime(new Date());
         taskRequest.setIntent(FhirTask.TaskIntent.ORDER);
         taskRequest.setStatus(FhirTask.TaskStatus.REQUESTED);
+        taskRequest.setIsSystemGeneratedTask(isSystemGenerated);
         return taskRequest;
     }
 }

--- a/api/src/main/java/org/openmrs/module/ipd/api/events/handler/impl/PatientAdmitEventHandler.java
+++ b/api/src/main/java/org/openmrs/module/ipd/api/events/handler/impl/PatientAdmitEventHandler.java
@@ -40,7 +40,7 @@ public class PatientAdmitEventHandler  implements IPDEventHandler {
                 .orElse(null);
         if (eventConfig != null) {
             for(TaskDetail taskDetail : eventConfig.getTasks()) {
-                TaskRequest taskRequest = IPDEventUtils.createNonMedicationTaskRequest(event, taskDetail.getName(), "nursing_activity_system");
+                TaskRequest taskRequest = IPDEventUtils.createNonMedicationTaskRequest(event, taskDetail.getName(), "nursing_activity_system",true);
                 Task task = taskMapper.fromRequest(taskRequest);
                 taskService.saveTask(task);
                 log.info("Task created " + taskDetail.getName());

--- a/api/src/main/java/org/openmrs/module/ipd/api/events/handler/impl/ShiftStartTaskEventHandler.java
+++ b/api/src/main/java/org/openmrs/module/ipd/api/events/handler/impl/ShiftStartTaskEventHandler.java
@@ -39,7 +39,7 @@ public class ShiftStartTaskEventHandler implements IPDEventHandler {
             String patientUuid = admittedPatient.getBedPatientAssignment().getPatient().getUuid();
             IPDEvent ipdEvent = new IPDEvent(null, patientUuid, event.getIpdEventType());
             for(TaskDetail taskDetail : eventConfig.getTasks()) {
-                TaskRequest taskRequest = IPDEventUtils.createNonMedicationTaskRequest(ipdEvent, taskDetail.getName(), "nursing_activity_system");
+                TaskRequest taskRequest = IPDEventUtils.createNonMedicationTaskRequest(ipdEvent, taskDetail.getName(), "nursing_activity_system",true);
                 Task task = taskMapper.fromRequest(taskRequest);
                 tasks.add(task);
             }


### PR DESCRIPTION
This PR sets the isSystemGenerated property to `true` for system generated tasks. This supports setting of `deamon` as creator for the tasks created by the system.

Depends on: https://github.com/Bahmni/openmrs-module-fhir2Extension/pull/64