### PR TITLE
BAH-4033 | Enhancement. Support for passing task type through eventConfig.json

### DIFF
--- a/api/src/main/java/org/openmrs/module/ipd/api/events/handler/impl/PatientAdmitEventHandler.java
+++ b/api/src/main/java/org/openmrs/module/ipd/api/events/handler/impl/PatientAdmitEventHandler.java
@@ -35,12 +35,12 @@ public class PatientAdmitEventHandler  implements IPDEventHandler {
     public void handleEvent(IPDEvent event) {
         List<ConfigDetail> configList = configLoader.getConfigs();
         ConfigDetail eventConfig = configList.stream()
-                .filter(config -> config.getType().equals(event.getIpdEventType().name()))
+                .filter(config -> config.getEvent().equals(event.getIpdEventType().name()))
                 .findFirst()
                 .orElse(null);
         if (eventConfig != null) {
             for(TaskDetail taskDetail : eventConfig.getTasks()) {
-                TaskRequest taskRequest = IPDEventUtils.createNonMedicationTaskRequest(event, taskDetail.getName(), "nursing_activity_system",true);
+                TaskRequest taskRequest = IPDEventUtils.createNonMedicationTaskRequest(event, taskDetail.getName(), taskDetail.getType(), true);
                 Task task = taskMapper.fromRequest(taskRequest);
                 taskService.saveTask(task);
                 log.info("Task created " + taskDetail.getName());

--- a/api/src/main/java/org/openmrs/module/ipd/api/events/handler/impl/RolloverTaskEventHandler.java
+++ b/api/src/main/java/org/openmrs/module/ipd/api/events/handler/impl/RolloverTaskEventHandler.java
@@ -35,7 +35,7 @@ public class RolloverTaskEventHandler implements IPDEventHandler {
     public void handleEvent(IPDEvent event) {
         List<ConfigDetail> configList = configLoader.getConfigs();
         ConfigDetail eventConfig = configList.stream()
-                .filter(config -> config.getType().equals(event.getIpdEventType().name()))
+                .filter(config -> config.getEvent().equals(event.getIpdEventType().name()))
                 .findFirst()
                 .orElse(null);
 

--- a/api/src/main/java/org/openmrs/module/ipd/api/events/handler/impl/ShiftStartTaskEventHandler.java
+++ b/api/src/main/java/org/openmrs/module/ipd/api/events/handler/impl/ShiftStartTaskEventHandler.java
@@ -39,7 +39,7 @@ public class ShiftStartTaskEventHandler implements IPDEventHandler {
             String patientUuid = admittedPatient.getBedPatientAssignment().getPatient().getUuid();
             IPDEvent ipdEvent = new IPDEvent(null, patientUuid, event.getIpdEventType());
             for(TaskDetail taskDetail : eventConfig.getTasks()) {
-                TaskRequest taskRequest = IPDEventUtils.createNonMedicationTaskRequest(ipdEvent, taskDetail.getName(), "nursing_activity_system",true);
+                TaskRequest taskRequest = IPDEventUtils.createNonMedicationTaskRequest(ipdEvent, taskDetail.getName(), taskDetail.getType(), true);
                 Task task = taskMapper.fromRequest(taskRequest);
                 tasks.add(task);
             }
@@ -52,7 +52,7 @@ public class ShiftStartTaskEventHandler implements IPDEventHandler {
     private ConfigDetail getEventConfig(IPDEvent event){
         List<ConfigDetail> configList = configLoader.getConfigs();
         ConfigDetail eventConfig = configList.stream()
-                .filter(config -> config.getType().equals(event.getIpdEventType().name()))
+                .filter(config -> config.getEvent().equals(event.getIpdEventType().name()))
                 .findFirst()
                 .orElse(null);
         return eventConfig;

--- a/api/src/main/java/org/openmrs/module/ipd/api/events/model/ConfigDetail.java
+++ b/api/src/main/java/org/openmrs/module/ipd/api/events/model/ConfigDetail.java
@@ -14,6 +14,6 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ConfigDetail {
-    private String type;
+    private String event;
     private List<TaskDetail> tasks;
 }

--- a/api/src/main/java/org/openmrs/module/ipd/api/events/model/TaskDetail.java
+++ b/api/src/main/java/org/openmrs/module/ipd/api/events/model/TaskDetail.java
@@ -13,4 +13,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class TaskDetail {
     private String name;
+    private String type;
 }


### PR DESCRIPTION
With the view of allowing implementers to allow configuring task types for the non-medication tasks, this PR brings in changes to read the task type from `eventsConfig.json`. This removes the hardcoding of `nursing_activity_system` as the task type for system generated tasks.