### PR TITLE
BAH-4061 | Refactor. Change Medication Administration Status Type As VarChar

### DIFF
--- a/api/src/test/java/org/openmrs/module/ipd/api/dao/impl/HibernateSlotDAOIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/module/ipd/api/dao/impl/HibernateSlotDAOIntegrationTest.java
@@ -285,12 +285,12 @@ public class HibernateSlotDAOIntegrationTest extends BaseIntegrationTest {
 
 
         MedicationAdministration medicationAdministration=new MedicationAdministration();
-        medicationAdministration.setStatus(testConcept);
+        medicationAdministration.setStatus("UNKNOWN");
         medicationAdministration.setAdministeredDateTime(DateTimeUtil.convertLocalDateTimeDate(medicationAdministeredTime));
         MedicationAdministration savedMedicationAdministration= medicationAdministrationDao.createOrUpdate(medicationAdministration);
 
         MedicationAdministration medicationAdministration2=new MedicationAdministration();
-        medicationAdministration2.setStatus(testConcept);
+        medicationAdministration2.setStatus("UNKNOWN");
         medicationAdministration2.setAdministeredDateTime(DateTimeUtil.convertLocalDateTimeDate(medicationAdministeredTime2));
         MedicationAdministration savedMedicationAdministration2= medicationAdministrationDao.createOrUpdate(medicationAdministration2);
 
@@ -376,12 +376,12 @@ public class HibernateSlotDAOIntegrationTest extends BaseIntegrationTest {
 
 
         MedicationAdministration medicationAdministration=new MedicationAdministration();
-        medicationAdministration.setStatus(testConcept);
+        medicationAdministration.setStatus("UNKNOWN");
         medicationAdministration.setAdministeredDateTime(DateTimeUtil.convertLocalDateTimeDate(medicationAdministeredTime));
         MedicationAdministration savedMedicationAdministration= medicationAdministrationDao.createOrUpdate(medicationAdministration);
 
         MedicationAdministration medicationAdministration2=new MedicationAdministration();
-        medicationAdministration2.setStatus(testConcept);
+        medicationAdministration2.setStatus("UNKNOWN");
         medicationAdministration2.setAdministeredDateTime(DateTimeUtil.convertLocalDateTimeDate(medicationAdministeredTime2));
         MedicationAdministration savedMedicationAdministration2= medicationAdministrationDao.createOrUpdate(medicationAdministration2);
 

--- a/api/src/test/java/org/openmrs/module/ipd/api/dao/impl/HibernateSlotDAOIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/module/ipd/api/dao/impl/HibernateSlotDAOIntegrationTest.java
@@ -285,12 +285,12 @@ public class HibernateSlotDAOIntegrationTest extends BaseIntegrationTest {
 
 
         MedicationAdministration medicationAdministration=new MedicationAdministration();
-        medicationAdministration.setStatus("UNKNOWN");
+        medicationAdministration.setStatus(org.hl7.fhir.r4.model.MedicationAdministration.MedicationAdministrationStatus.COMPLETED);
         medicationAdministration.setAdministeredDateTime(DateTimeUtil.convertLocalDateTimeDate(medicationAdministeredTime));
         MedicationAdministration savedMedicationAdministration= medicationAdministrationDao.createOrUpdate(medicationAdministration);
 
         MedicationAdministration medicationAdministration2=new MedicationAdministration();
-        medicationAdministration2.setStatus("UNKNOWN");
+        medicationAdministration2.setStatus(org.hl7.fhir.r4.model.MedicationAdministration.MedicationAdministrationStatus.COMPLETED);
         medicationAdministration2.setAdministeredDateTime(DateTimeUtil.convertLocalDateTimeDate(medicationAdministeredTime2));
         MedicationAdministration savedMedicationAdministration2= medicationAdministrationDao.createOrUpdate(medicationAdministration2);
 
@@ -376,12 +376,12 @@ public class HibernateSlotDAOIntegrationTest extends BaseIntegrationTest {
 
 
         MedicationAdministration medicationAdministration=new MedicationAdministration();
-        medicationAdministration.setStatus("UNKNOWN");
+        medicationAdministration.setStatus(org.hl7.fhir.r4.model.MedicationAdministration.MedicationAdministrationStatus.COMPLETED);
         medicationAdministration.setAdministeredDateTime(DateTimeUtil.convertLocalDateTimeDate(medicationAdministeredTime));
         MedicationAdministration savedMedicationAdministration= medicationAdministrationDao.createOrUpdate(medicationAdministration);
 
         MedicationAdministration medicationAdministration2=new MedicationAdministration();
-        medicationAdministration2.setStatus("UNKNOWN");
+        medicationAdministration2.setStatus(org.hl7.fhir.r4.model.MedicationAdministration.MedicationAdministrationStatus.COMPLETED);
         medicationAdministration2.setAdministeredDateTime(DateTimeUtil.convertLocalDateTimeDate(medicationAdministeredTime2));
         MedicationAdministration savedMedicationAdministration2= medicationAdministrationDao.createOrUpdate(medicationAdministration2);
 

--- a/api/src/test/resources/scheduleMedicationsTestData.xml
+++ b/api/src/test/resources/scheduleMedicationsTestData.xml
@@ -29,8 +29,8 @@
     <ipd_schedule schedule_id="1" uuid="23255323d-e887-4485-bc19-756cdbf00001" subject_reference_id="2" actor_reference_id="1" service_type_id="101" active="true" start_date="2024-01-27 15:48:00.0" creator="1" date_created="2024-01-27 15:48:00.0" voided="false" visit_id="1"/>
 
     <concept concept_id="103" retired="false" datatype_id="4" class_id="11" is_set="false" creator="1" date_created="2024-01-27 15:48:00.0" version="" uuid="0abca361-f6bf-49cc-97de-b2f37f099125"/>
-    <medication_administration medication_administration_id="1" uuid="23255323d-e887-4485-bc19-756cdbf10101" status="103" creator="1" date_created="2024-01-27 20:00:00.0" voided="false"/>
-    <medication_administration medication_administration_id="2" uuid="23255323d-e887-4485-bc19-756cdbf10102" status="103" creator="1" date_created="2024-01-28 14:00:00.0" voided="false"/>
+    <medication_administration medication_administration_id="1" uuid="23255323d-e887-4485-bc19-756cdbf10101" status="COMPLETED" creator="1" date_created="2024-01-27 20:00:00.0" voided="false"/>
+    <medication_administration medication_administration_id="2" uuid="23255323d-e887-4485-bc19-756cdbf10102" status="COMPLETED" creator="1" date_created="2024-01-28 14:00:00.0" voided="false"/>
 
     <ipd_slot slot_id="1" uuid="23255323d-e887-4485-bc19-756cdbf00101" service_type_id="101" schedule_id="1" status="COMPLETED" start_date_time="2024-01-27 20:00:00.0" creator="1" date_created="2024-01-27 15:48:00.0" voided="false" order_id="1" medication_administration_id="1"/>
     <ipd_slot slot_id="2" uuid="23255323d-e887-4485-bc19-756cdbf00102" service_type_id="101" schedule_id="1" status="SCHEDULED" start_date_time="2024-01-28 08:00:00.0" creator="1" date_created="2024-01-27 15:48:00.0" voided="false" order_id="1"/>

--- a/omod/src/main/java/org/openmrs/module/ipd/contract/MedicationAdministrationResponse.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/contract/MedicationAdministrationResponse.java
@@ -38,7 +38,7 @@ public class MedicationAdministrationResponse {
         if (openmrsMedicationAdministration == null) {
             return null;
         }
-        String status = openmrsMedicationAdministration.getStatus() != null ? openmrsMedicationAdministration.getStatus() : null;
+        String status = openmrsMedicationAdministration.getStatus().toCode() != null ? openmrsMedicationAdministration.getStatus().toCode() : null;
         String statusReason = openmrsMedicationAdministration.getStatusReason() != null ? openmrsMedicationAdministration.getStatusReason().getDisplayString() : null;
         String patientUuid = openmrsMedicationAdministration.getPatient() != null ? openmrsMedicationAdministration.getPatient().getUuid() : null;
         String encounterUuid = openmrsMedicationAdministration.getEncounter() != null ? openmrsMedicationAdministration.getEncounter().getUuid() : null;

--- a/omod/src/main/java/org/openmrs/module/ipd/contract/MedicationAdministrationResponse.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/contract/MedicationAdministrationResponse.java
@@ -38,7 +38,7 @@ public class MedicationAdministrationResponse {
         if (openmrsMedicationAdministration == null) {
             return null;
         }
-        String status = openmrsMedicationAdministration.getStatus() != null ? openmrsMedicationAdministration.getStatus().getShortNameInLocale(Context.getLocale()).getName() : null;
+        String status = openmrsMedicationAdministration.getStatus() != null ? openmrsMedicationAdministration.getStatus() : null;
         String statusReason = openmrsMedicationAdministration.getStatusReason() != null ? openmrsMedicationAdministration.getStatusReason().getDisplayString() : null;
         String patientUuid = openmrsMedicationAdministration.getPatient() != null ? openmrsMedicationAdministration.getPatient().getUuid() : null;
         String encounterUuid = openmrsMedicationAdministration.getEncounter() != null ? openmrsMedicationAdministration.getEncounter().getUuid() : null;

--- a/omod/src/main/java/org/openmrs/module/ipd/controller/IPDMedicationAdministrationController.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/controller/IPDMedicationAdministrationController.java
@@ -13,6 +13,8 @@ import org.openmrs.module.ipd.util.PrivilegeConstants;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.RestUtil;
 import org.openmrs.module.webservices.rest.web.v1_0.controller.BaseRestController;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -30,6 +32,7 @@ public class IPDMedicationAdministrationController extends BaseRestController {
 
     private final IPDMedicationAdministrationService ipdMedicationAdministrationService;
     private final MedicationAdministrationFactory medicationAdministrationFactory;
+    private static final Logger log = LoggerFactory.getLogger(IPDMedicationAdministrationController.class);
 
     @Autowired
     public IPDMedicationAdministrationController(IPDMedicationAdministrationService ipdMedicationAdministrationService,

--- a/omod/src/main/java/org/openmrs/module/ipd/factory/MedicationAdministrationFactory.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/factory/MedicationAdministrationFactory.java
@@ -2,7 +2,6 @@ package org.openmrs.module.ipd.factory;
 
 import org.openmrs.DrugOrder;
 import org.openmrs.api.context.Context;
-import org.openmrs.module.fhir2.apiext.translators.MedicationAdministrationStatusTranslator;
 import org.openmrs.module.fhir2.apiext.translators.MedicationAdministrationTranslator;
 import org.openmrs.module.ipd.api.model.MedicationAdministration;
 import org.openmrs.module.ipd.api.model.MedicationAdministrationNote;
@@ -20,13 +19,10 @@ import java.util.List;
 public class MedicationAdministrationFactory {
 
     private MedicationAdministrationTranslator medicationAdministrationTranslator;
-    private MedicationAdministrationStatusTranslator medicationAdministrationStatusTranslator;
 
     @Autowired
-    public MedicationAdministrationFactory(MedicationAdministrationTranslator medicationAdministrationTranslator,
-                                           MedicationAdministrationStatusTranslator medicationAdministrationStatusTranslator) {
+    public MedicationAdministrationFactory(MedicationAdministrationTranslator medicationAdministrationTranslator) {
         this.medicationAdministrationTranslator = medicationAdministrationTranslator;
-        this.medicationAdministrationStatusTranslator = medicationAdministrationStatusTranslator;
     }
 
     public MedicationAdministration mapRequestToMedicationAdministration(MedicationAdministrationRequest request, MedicationAdministration existingMedicationAdministration) {
@@ -34,12 +30,9 @@ public class MedicationAdministrationFactory {
         MedicationAdministration medicationAdministration = new MedicationAdministration();
         if (existingMedicationAdministration ==null ||  existingMedicationAdministration.getId() == null) {
             medicationAdministration.setAdministeredDateTime(request.getAdministeredDateTimeAsLocaltime());
-            String status = request.getStatus();
-            org.hl7.fhir.r4.model.MedicationAdministration.MedicationAdministrationStatus medicationAdministrationStatus =
-                    org.hl7.fhir.r4.model.MedicationAdministration.MedicationAdministrationStatus.fromCode(status);
-
+            org.hl7.fhir.r4.model.MedicationAdministration.MedicationAdministrationStatus medicationAdministrationStatus = org.hl7.fhir.r4.model.MedicationAdministration.MedicationAdministrationStatus.fromCode(request.getStatus());
             medicationAdministrationStatus = (medicationAdministrationStatus != null) ? medicationAdministrationStatus : org.hl7.fhir.r4.model.MedicationAdministration.MedicationAdministrationStatus.fromCode("unknown");
-            medicationAdministration.setStatus(medicationAdministrationStatusTranslator.toOpenmrsType(medicationAdministrationStatus));
+            medicationAdministration.setStatus(medicationAdministrationStatus);
             medicationAdministration.setPatient(Context.getPatientService().getPatientByUuid(request.getPatientUuid()));
             medicationAdministration.setEncounter(Context.getEncounterService().getEncounterByUuid(request.getEncounterUuid()));
             medicationAdministration.setDrugOrder((DrugOrder) Context.getOrderService().getOrderByUuid(request.getOrderUuid()));

--- a/omod/src/main/java/org/openmrs/module/ipd/factory/MedicationAdministrationFactory.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/factory/MedicationAdministrationFactory.java
@@ -30,9 +30,7 @@ public class MedicationAdministrationFactory {
         MedicationAdministration medicationAdministration = new MedicationAdministration();
         if (existingMedicationAdministration ==null ||  existingMedicationAdministration.getId() == null) {
             medicationAdministration.setAdministeredDateTime(request.getAdministeredDateTimeAsLocaltime());
-            org.hl7.fhir.r4.model.MedicationAdministration.MedicationAdministrationStatus medicationAdministrationStatus = org.hl7.fhir.r4.model.MedicationAdministration.MedicationAdministrationStatus.fromCode(request.getStatus());
-            medicationAdministrationStatus = (medicationAdministrationStatus != null) ? medicationAdministrationStatus : org.hl7.fhir.r4.model.MedicationAdministration.MedicationAdministrationStatus.fromCode("unknown");
-            medicationAdministration.setStatus(medicationAdministrationStatus);
+            medicationAdministration.setStatus(org.hl7.fhir.r4.model.MedicationAdministration.MedicationAdministrationStatus.fromCode(request.getStatus()));
             medicationAdministration.setPatient(Context.getPatientService().getPatientByUuid(request.getPatientUuid()));
             medicationAdministration.setEncounter(Context.getEncounterService().getEncounterByUuid(request.getEncounterUuid()));
             medicationAdministration.setDrugOrder((DrugOrder) Context.getOrderService().getOrderByUuid(request.getOrderUuid()));

--- a/omod/src/main/java/org/openmrs/module/ipd/factory/MedicationAdministrationFactory.java
+++ b/omod/src/main/java/org/openmrs/module/ipd/factory/MedicationAdministrationFactory.java
@@ -12,7 +12,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 
@@ -35,7 +34,12 @@ public class MedicationAdministrationFactory {
         MedicationAdministration medicationAdministration = new MedicationAdministration();
         if (existingMedicationAdministration ==null ||  existingMedicationAdministration.getId() == null) {
             medicationAdministration.setAdministeredDateTime(request.getAdministeredDateTimeAsLocaltime());
-            medicationAdministration.setStatus(medicationAdministrationStatusTranslator.toOpenmrsType(org.hl7.fhir.r4.model.MedicationAdministration.MedicationAdministrationStatus.fromCode(request.getStatus())));
+            String status = request.getStatus();
+            org.hl7.fhir.r4.model.MedicationAdministration.MedicationAdministrationStatus medicationAdministrationStatus =
+                    org.hl7.fhir.r4.model.MedicationAdministration.MedicationAdministrationStatus.fromCode(status);
+
+            medicationAdministrationStatus = (medicationAdministrationStatus != null) ? medicationAdministrationStatus : org.hl7.fhir.r4.model.MedicationAdministration.MedicationAdministrationStatus.fromCode("unknown");
+            medicationAdministration.setStatus(medicationAdministrationStatusTranslator.toOpenmrsType(medicationAdministrationStatus));
             medicationAdministration.setPatient(Context.getPatientService().getPatientByUuid(request.getPatientUuid()));
             medicationAdministration.setEncounter(Context.getEncounterService().getEncounterByUuid(request.getEncounterUuid()));
             medicationAdministration.setDrugOrder((DrugOrder) Context.getOrderService().getOrderByUuid(request.getOrderUuid()));


### PR DESCRIPTION
JIRA -> [BAH-4061](https://bahmni.atlassian.net/browse/BAH-4061)

This PR aims to update the Medication Administration Status Type As VarChar. The IPD module adds a schema which stores Medication Administration. The model contains a status column which references concept table. As per FHIR model, the [status](https://build.fhir.org/medicationadministration-definitions.html#MedicationAdministration.status) is a enum field, and it should not refer to a concept.

This PR is to be merged post the https://github.com/Bahmni/openmrs-module-medicationadministration/pull/7 PR raised in the Bahmni/openmrs-module-medicationadministration.