### PR TITLE
BAH-4093 | Add. Default value for config file path property.

### DIFF
--- a/api/src/main/java/org/openmrs/module/ipd/api/events/ConfigLoader.java
+++ b/api/src/main/java/org/openmrs/module/ipd/api/events/ConfigLoader.java
@@ -20,7 +20,7 @@ public class ConfigLoader {
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
-    @Value("${config-file.path}")
+    @Value("${config-file.path:/etc/bahmni_config/openmrs/apps/ipdDashboard/eventsConfig.json}")
     private String routeConfigurationFileLocation;
 
     public List<ConfigDetail> getConfigs() {

--- a/api/src/main/java/org/openmrs/module/ipd/api/events/ConfigLoader.java
+++ b/api/src/main/java/org/openmrs/module/ipd/api/events/ConfigLoader.java
@@ -20,8 +20,8 @@ public class ConfigLoader {
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
-    @Value("${config-file.path:/etc/bahmni_config/openmrs/apps/ipdDashboard/eventsConfig.json}")
-    private String routeConfigurationFileLocation;
+    @Value("${ipd.events_config.file_path:/etc/bahmni_config/openmrs/apps/ipdDashboard/eventsConfig.json}")
+    private String eventsConfigurationFileLocation;
 
     public List<ConfigDetail> getConfigs() {
         if (configs.isEmpty()) {
@@ -32,10 +32,10 @@ public class ConfigLoader {
 
     private void loadConfiguration() {
         try {
-            File routeConfigurationFile = new FileSystemResource(routeConfigurationFileLocation).getFile();
+            File routeConfigurationFile = new FileSystemResource(eventsConfigurationFileLocation).getFile();
             this.configs = objectMapper.readValue(routeConfigurationFile, new TypeReference<List<ConfigDetail>>() {});
         } catch (IOException exception) {
-            log.error("Failed to load configuration for file : " + routeConfigurationFileLocation, exception);
+            log.error("Failed to load configuration for file : " + eventsConfigurationFileLocation, exception);
         }
     }
 }

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -1,3 +1,3 @@
 
 # Route definitions
-config-file.path=/etc/bahmni_config/openmrs/apps/ipdDashboard/eventsConfig.json
+ipd.events_config.file_path=/etc/bahmni_config/openmrs/apps/ipdDashboard/eventsConfig.json


### PR DESCRIPTION
This PR adds a default value for the `config-file.path` property used by the ConfigLoader class. 

_**Note**_: This is a temporary workaround, since the loading of appointments module and IPD module together causes the value not being read from application.properties set.