### PR TITLE
BAH-4106 | Fix. Create beans for scheduler task classes to initialize context properly

### DIFF
--- a/api/src/main/java/org/openmrs/module/ipd/api/scheduler/tasks/RollOverNonMedicationTasks.java
+++ b/api/src/main/java/org/openmrs/module/ipd/api/scheduler/tasks/RollOverNonMedicationTasks.java
@@ -1,21 +1,17 @@
 package org.openmrs.module.ipd.api.scheduler.tasks;
 
+import org.openmrs.api.context.Context;
 import org.openmrs.module.ipd.api.events.IPDEventManager;
 import org.openmrs.module.ipd.api.events.model.IPDEvent;
 import org.openmrs.module.ipd.api.events.model.IPDEventType;
 import org.openmrs.scheduler.tasks.AbstractTask;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
-import org.springframework.stereotype.Component;
 
 
-public class RollOverNonMedicationTasks extends AbstractTask implements ApplicationContextAware {
-
-    private static ApplicationContext context;
+public class RollOverNonMedicationTasks extends AbstractTask {
 
     @Override
     public void execute() {
-        IPDEventManager eventManager = context.getBean(IPDEventManager.class);
+        IPDEventManager eventManager = Context.getRegisteredComponents(IPDEventManager.class).get(0);
         IPDEventType eventType = eventManager.getEventTypeForEncounter(String.valueOf(IPDEventType.ROLLOVER_TASK));
         if (eventType != null) {
             IPDEvent ipdEvent = new IPDEvent(null, null, eventType);
@@ -23,8 +19,4 @@ public class RollOverNonMedicationTasks extends AbstractTask implements Applicat
         }
     }
 
-    @Override
-    public void setApplicationContext(ApplicationContext applicationContext) {
-        this.context = applicationContext;
-    }
 }

--- a/api/src/main/java/org/openmrs/module/ipd/api/scheduler/tasks/ShiftStartTasks.java
+++ b/api/src/main/java/org/openmrs/module/ipd/api/scheduler/tasks/ShiftStartTasks.java
@@ -1,20 +1,17 @@
 package org.openmrs.module.ipd.api.scheduler.tasks;
 
+import org.openmrs.api.context.Context;
 import org.openmrs.module.ipd.api.events.IPDEventManager;
 import org.openmrs.module.ipd.api.events.model.IPDEvent;
 import org.openmrs.module.ipd.api.events.model.IPDEventType;
 import org.openmrs.scheduler.tasks.AbstractTask;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
-import org.springframework.stereotype.Component;
 
 
-public class ShiftStartTasks extends AbstractTask implements ApplicationContextAware {
+public class ShiftStartTasks extends AbstractTask {
 
-    private static ApplicationContext context;
     @Override
     public void execute() {
-        IPDEventManager eventManager = context.getBean(IPDEventManager.class);
+        IPDEventManager eventManager = Context.getRegisteredComponents(IPDEventManager.class).get(0);
         IPDEventType eventType = eventManager.getEventTypeForEncounter(String.valueOf(IPDEventType.SHIFT_START_TASK));
         if (eventType != null) {
             IPDEvent ipdEvent = new IPDEvent(null, null, eventType);
@@ -22,8 +19,4 @@ public class ShiftStartTasks extends AbstractTask implements ApplicationContextA
         }
     }
 
-    @Override
-    public void setApplicationContext(ApplicationContext applicationContext) {
-        this.context = applicationContext;
-    }
 }

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -123,7 +123,4 @@
         </property>
     </bean>
 
-    <bean id="shiftStartTasks" class="org.openmrs.module.ipd.api.scheduler.tasks.ShiftStartTasks"/>
-    <bean id="rollOverNonMedicationTasks" class="org.openmrs.module.ipd.api.scheduler.tasks.RollOverNonMedicationTasks"/>
-
 </beans>

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -123,4 +123,7 @@
         </property>
     </bean>
 
+    <bean id="shiftStartTasks" class="org.openmrs.module.ipd.api.scheduler.tasks.ShiftStartTasks"/>
+    <bean id="rollOverNonMedicationTasks" class="org.openmrs.module.ipd.api.scheduler.tasks.RollOverNonMedicationTasks"/>
+
 </beans>


### PR DESCRIPTION
This PR adds a bean creation to moduleApplicationContext.xml for scheduler.tasks classes. This is needed because the implementation of the classes depends on `context` object which get initialized only when a bean is created either by using @Component annotation or bean through xml.