### PR TITLE
Bah 4503 dependency | Upgrade openmrs-module-ipd from OpenMRS Platform 2.5.12 to 2.6.15

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -129,7 +129,7 @@
 
 		<dependency>
 			<groupId>org.openmrs.module</groupId>
-			<artifactId>webservices.rest-omod-2.0</artifactId>
+			<artifactId>webservices.rest-omod</artifactId>
 			<scope>provided</scope>
 		</dependency>
 

--- a/api/src/main/java/org/openmrs/module/ipd/api/dao/impl/HibernateSlotDAO.java
+++ b/api/src/main/java/org/openmrs/module/ipd/api/dao/impl/HibernateSlotDAO.java
@@ -37,7 +37,7 @@ public class HibernateSlotDAO implements SlotDAO {
 
 	@Override
 	public Slot getSlotByUUID(String uuid) throws DAOException {
-		Slot s = (Slot)this.sessionFactory.getCurrentSession().createQuery("from Slot s where s.uuid = :uuid").setString("uuid", uuid).uniqueResult();
+		Slot s = (Slot)this.sessionFactory.getCurrentSession().createQuery("from Slot s where s.uuid = :uuid").setParameter("uuid", uuid).uniqueResult();
 		return s;
 	}
 

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -5,8 +5,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:component-scan base-package="org.openmrs.module.ipd.api.events"/>
     <context:component-scan base-package="org.openmrs.module.ipd.api.translators"/>

--- a/api/src/test/java/org/openmrs/module/ipd/api/AdminServicePrimaryPostProcessor.java
+++ b/api/src/test/java/org/openmrs/module/ipd/api/AdminServicePrimaryPostProcessor.java
@@ -1,0 +1,22 @@
+package org.openmrs.module.ipd.api;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+
+/**
+ * Marks 'adminService' as the primary AdministrationService bean so that Spring 5.3+
+ * can resolve @Autowired AdministrationService injection unambiguously in integration tests
+ * (avoids NoUniqueBeanDefinitionException caused by both adminService and adminServiceTarget).
+ */
+public class AdminServicePrimaryPostProcessor implements BeanFactoryPostProcessor {
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+        if (beanFactory.containsBeanDefinition("adminService")) {
+            BeanDefinition bd = beanFactory.getBeanDefinition("adminService");
+            bd.setPrimary(true);
+        }
+    }
+}

--- a/api/src/test/java/org/openmrs/module/ipd/api/service/impl/WardServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/ipd/api/service/impl/WardServiceImplTest.java
@@ -1,0 +1,182 @@
+package org.openmrs.module.ipd.api.service.impl;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.openmrs.Location;
+import org.openmrs.Provider;
+import org.openmrs.api.LocationService;
+import org.openmrs.api.ProviderService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.ipd.api.dao.WardDAO;
+import org.openmrs.module.ipd.api.model.AdmittedPatient;
+import org.openmrs.module.ipd.api.model.WardPatientsSummary;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Context.class})
+@SuppressStaticInitializationFor({"org.openmrs.api.context.Context", "org.openmrs.Provider"})
+@PowerMockIgnore({"javax.management.*", "javax.xml.*", "org.xml.sax.*", "org.w3c.dom.*", "com.sun.*", "sun.*"})
+public class WardServiceImplTest {
+
+    @InjectMocks
+    private WardServiceImpl wardService;
+
+    @Mock
+    private WardDAO wardDAO;
+
+    @Mock
+    private LocationService locationService;
+
+    @Mock
+    private ProviderService providerService;
+
+    @Before
+    public void setUp() {
+        PowerMockito.mockStatic(Context.class);
+        Mockito.when(Context.getService(LocationService.class)).thenReturn(locationService);
+        Mockito.when(Context.getProviderService()).thenReturn(providerService);
+    }
+
+    @Test
+    public void shouldGetWardPatientSummaryGivenWardUuidAndProviderUuid() {
+        String wardUuid = "ward-uuid-1";
+        String providerUuid = "provider-uuid-1";
+
+        Location location = new Location();
+        location.setUuid(wardUuid);
+
+        Provider provider = new Provider();
+        provider.setUuid(providerUuid);
+
+        WardPatientsSummary expectedSummary = new WardPatientsSummary(5L, 3L);
+
+        Mockito.when(locationService.getLocationByUuid(wardUuid)).thenReturn(location);
+        Mockito.when(providerService.getProviderByUuid(providerUuid)).thenReturn(provider);
+        Mockito.when(wardDAO.getWardPatientSummary(Mockito.eq(location), Mockito.eq(provider), Mockito.any()))
+                .thenReturn(expectedSummary);
+
+        WardPatientsSummary result = wardService.getIPDWardPatientSummary(wardUuid, providerUuid);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(5L, result.getTotalPatients().longValue());
+        Assert.assertEquals(3L, result.getTotalProviderPatients().longValue());
+        Mockito.verify(locationService, Mockito.times(1)).getLocationByUuid(wardUuid);
+        Mockito.verify(providerService, Mockito.times(1)).getProviderByUuid(providerUuid);
+        Mockito.verify(wardDAO, Mockito.times(1))
+                .getWardPatientSummary(Mockito.eq(location), Mockito.eq(provider), Mockito.any());
+    }
+
+    @Test
+    public void shouldGetWardPatientsByUuidGivenWardUuid() {
+        String wardUuid = "ward-uuid-1";
+
+        Location location = new Location();
+        location.setUuid(wardUuid);
+
+        List<AdmittedPatient> expectedPatients = Collections.emptyList();
+
+        Mockito.when(locationService.getLocationByUuid(wardUuid)).thenReturn(location);
+        Mockito.when(wardDAO.getAdmittedPatients(location, null, null, null)).thenReturn(expectedPatients);
+
+        List<AdmittedPatient> result = wardService.getWardPatientsByUuid(wardUuid, null);
+
+        Assert.assertNotNull(result);
+        Mockito.verify(locationService, Mockito.times(1)).getLocationByUuid(wardUuid);
+        Mockito.verify(wardDAO, Mockito.times(1)).getAdmittedPatients(location, null, null, null);
+    }
+
+    @Test
+    public void shouldGetWardPatientsByUuidWithSortByGivenWardUuid() {
+        String wardUuid = "ward-uuid-1";
+        String sortBy = "bedNumber";
+
+        Location location = new Location();
+        location.setUuid(wardUuid);
+
+        List<AdmittedPatient> expectedPatients = Collections.emptyList();
+
+        Mockito.when(locationService.getLocationByUuid(wardUuid)).thenReturn(location);
+        Mockito.when(wardDAO.getAdmittedPatients(location, null, null, sortBy)).thenReturn(expectedPatients);
+
+        List<AdmittedPatient> result = wardService.getWardPatientsByUuid(wardUuid, sortBy);
+
+        Assert.assertNotNull(result);
+        Mockito.verify(wardDAO, Mockito.times(1)).getAdmittedPatients(location, null, null, sortBy);
+    }
+
+    @Test
+    public void shouldGetPatientsByWardAndProviderGivenWardUuidAndProviderUuid() {
+        String wardUuid = "ward-uuid-1";
+        String providerUuid = "provider-uuid-1";
+        String sortBy = "admissionDate";
+
+        Location location = new Location();
+        location.setUuid(wardUuid);
+
+        Provider provider = new Provider();
+        provider.setUuid(providerUuid);
+
+        List<AdmittedPatient> expectedPatients = Collections.emptyList();
+
+        Mockito.when(locationService.getLocationByUuid(wardUuid)).thenReturn(location);
+        Mockito.when(providerService.getProviderByUuid(providerUuid)).thenReturn(provider);
+        Mockito.when(wardDAO.getAdmittedPatients(Mockito.eq(location), Mockito.eq(provider), Mockito.any(), Mockito.eq(sortBy)))
+                .thenReturn(expectedPatients);
+
+        List<AdmittedPatient> result = wardService.getPatientsByWardAndProvider(wardUuid, providerUuid, sortBy);
+
+        Assert.assertNotNull(result);
+        Mockito.verify(locationService, Mockito.times(1)).getLocationByUuid(wardUuid);
+        Mockito.verify(providerService, Mockito.times(1)).getProviderByUuid(providerUuid);
+        Mockito.verify(wardDAO, Mockito.times(1))
+                .getAdmittedPatients(Mockito.eq(location), Mockito.eq(provider), Mockito.any(), Mockito.eq(sortBy));
+    }
+
+    @Test
+    public void shouldSearchWardPatientsGivenWardUuidAndSearchCriteria() {
+        String wardUuid = "ward-uuid-1";
+        List<String> searchKeys = Arrays.asList("bedNumber", "patientName");
+        String searchValue = "101";
+        String sortBy = "bedNumber";
+
+        Location location = new Location();
+        location.setUuid(wardUuid);
+
+        List<AdmittedPatient> expectedPatients = Collections.emptyList();
+
+        Mockito.when(locationService.getLocationByUuid(wardUuid)).thenReturn(location);
+        Mockito.when(wardDAO.searchAdmittedPatients(location, searchKeys, searchValue, sortBy))
+                .thenReturn(expectedPatients);
+
+        List<AdmittedPatient> result = wardService.searchWardPatients(wardUuid, searchKeys, searchValue, sortBy);
+
+        Assert.assertNotNull(result);
+        Mockito.verify(locationService, Mockito.times(1)).getLocationByUuid(wardUuid);
+        Mockito.verify(wardDAO, Mockito.times(1)).searchAdmittedPatients(location, searchKeys, searchValue, sortBy);
+    }
+
+    @Test
+    public void shouldGetAllAdmittedPatients() {
+        List<AdmittedPatient> expectedPatients = Collections.emptyList();
+
+        Mockito.when(wardDAO.getAdmittedPatients(null, null, null, null)).thenReturn(expectedPatients);
+
+        List<AdmittedPatient> result = wardService.getAdmittedPatients();
+
+        Assert.assertNotNull(result);
+        Mockito.verify(wardDAO, Mockito.times(1)).getAdmittedPatients(null, null, null, null);
+    }
+}

--- a/api/src/test/resources/TestingApplicationContext.xml
+++ b/api/src/test/resources/TestingApplicationContext.xml
@@ -3,11 +3,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-  		    http://www.springframework.org/schema/beans/spring-beans.xsd
-  		    http://www.springframework.org/schema/beans/spring-beans.xsd
-  		    http://www.springframework.org/schema/context
-  		    http://www.springframework.org/schema/context/spring-context.xsd">
-  		    http://www.springframework.org/schema/context/spring-context.xsd">
+                           http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/context
+                           http://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:component-scan base-package="org.openmrs.module.ipd.api"/>
     <context:annotation-config/>

--- a/api/src/test/resources/TestingApplicationContext.xml
+++ b/api/src/test/resources/TestingApplicationContext.xml
@@ -3,9 +3,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-  		    http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+  		    http://www.springframework.org/schema/beans/spring-beans.xsd
   		    http://www.springframework.org/schema/context
-  		    http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+  		    http://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:component-scan base-package="org.openmrs.module.ipd.api"/>
     <context:annotation-config/>

--- a/api/src/test/resources/TestingApplicationContext.xml
+++ b/api/src/test/resources/TestingApplicationContext.xml
@@ -20,6 +20,13 @@
                 <value>classpath:hibernate.cfg.xml</value>
             </list>
         </property>
+        <property name="mappingResources">
+            <list>
+                <value>MedicationAdministration.hbm.xml</value>
+                <value>MedicationAdministrationPerformer.hbm.xml</value>
+                <value>MedicationAdministrationNote.hbm.xml</value>
+            </list>
+        </property>
         <property name="packagesToScan">
             <list>
                 <value>org.openmrs</value>

--- a/api/src/test/resources/TestingApplicationContext.xml
+++ b/api/src/test/resources/TestingApplicationContext.xml
@@ -4,7 +4,9 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
   		    http://www.springframework.org/schema/beans/spring-beans.xsd
+  		    http://www.springframework.org/schema/beans/spring-beans.xsd
   		    http://www.springframework.org/schema/context
+  		    http://www.springframework.org/schema/context/spring-context.xsd">
   		    http://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:component-scan base-package="org.openmrs.module.ipd.api"/>

--- a/api/src/test/resources/TestingApplicationContext.xml
+++ b/api/src/test/resources/TestingApplicationContext.xml
@@ -9,6 +9,11 @@
 
     <context:component-scan base-package="org.openmrs.module.ipd.api"/>
     <context:annotation-config/>
+
+    <!-- Marks adminService as @Primary to resolve Spring 5.3 NoUniqueBeanDefinitionException
+         when both adminService (proxy) and adminServiceTarget (impl) are in context -->
+    <bean class="org.openmrs.module.ipd.api.AdminServicePrimaryPostProcessor"/>
+
     <bean id="sessionFactory" class="org.openmrs.api.db.hibernate.HibernateSessionFactoryBean">
         <property name="configLocations">
             <list>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -186,6 +186,26 @@
 			<artifactId>${project.parent.artifactId}-api</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-api-mockito2</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-module-junit4</artifactId>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
 
 </project>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -71,7 +71,7 @@
 							<includeGroupIds>${project.parent.groupId}</includeGroupIds>
 							<includeArtifactIds>${project.parent.artifactId}-api</includeArtifactIds>
 							<excludeTransitive>true</excludeTransitive>
-							<includes>**/*</includes>
+							<includes>**/*.xml,**/*.properties</includes>
 							<outputDirectory>${project.build.directory}/classes</outputDirectory>
 						</configuration>
 					</execution>

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -49,5 +49,7 @@
 		<description>Allows to Get Medication Tasks</description>
 	</privilege>
 	<activator>org.openmrs.module.ipd.api.IPDActivator</activator>
+
+	<packagesWithMappedClasses>org.openmrs.module.ipd.api.model</packagesWithMappedClasses>
 </module>
 

--- a/omod/src/main/resources/webModuleApplicationContext.xml
+++ b/omod/src/main/resources/webModuleApplicationContext.xml
@@ -3,8 +3,8 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:context="http://www.springframework.org/schema/context"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-  		    http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-  		    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+  		    http://www.springframework.org/schema/beans/spring-beans.xsd
+  		    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
 	<context:component-scan base-package="org.openmrs.module.ipd.web"/>
 </beans>

--- a/omod/src/test/java/org/openmrs/module/ipd/web/service/impl/IPDScheduleServiceImplTest.java
+++ b/omod/src/test/java/org/openmrs/module/ipd/web/service/impl/IPDScheduleServiceImplTest.java
@@ -1,0 +1,250 @@
+package org.openmrs.module.ipd.web.service.impl;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openmrs.Concept;
+import org.openmrs.Patient;
+import org.openmrs.Visit;
+import org.openmrs.api.ConceptService;
+import org.openmrs.api.OrderService;
+import org.openmrs.api.PatientService;
+import org.openmrs.api.VisitService;
+import org.openmrs.module.ipd.api.model.Reference;
+import org.openmrs.module.ipd.api.model.ServiceType;
+import org.openmrs.module.ipd.api.model.Slot;
+import org.openmrs.module.ipd.api.service.ReferenceService;
+import org.openmrs.module.ipd.api.service.ScheduleService;
+import org.openmrs.module.ipd.api.service.SlotService;
+import org.openmrs.module.ipd.web.factory.ScheduleFactory;
+import org.openmrs.module.ipd.web.factory.SlotFactory;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IPDScheduleServiceImplTest {
+
+    @InjectMocks
+    private IPDScheduleServiceImpl ipdScheduleService;
+
+    @Mock
+    private ScheduleService scheduleService;
+    @Mock
+    private ScheduleFactory scheduleFactory;
+    @Mock
+    private SlotFactory slotFactory;
+    @Mock
+    private SlotService slotService;
+    @Mock
+    private SlotTimeCreationService slotTimeCreationService;
+    @Mock
+    private ConceptService conceptService;
+    @Mock
+    private ReferenceService referenceService;
+    @Mock
+    private VisitService visitService;
+    @Mock
+    private PatientService patientService;
+    @Mock
+    private OrderService orderService;
+
+    // -------- getMedicationSlots(patientUuid, serviceType, forDate) --------
+
+    @Test
+    public void shouldReturnEmptyListWhenReferenceNotFoundForGetMedicationSlotsByDate() {
+        String patientUuid = "patient-uuid-1";
+        LocalDate forDate = LocalDate.now();
+        Concept concept = new Concept();
+
+        Mockito.when(conceptService.getConceptByName(ServiceType.MEDICATION_REQUEST.conceptName())).thenReturn(concept);
+        Mockito.when(referenceService.getReferenceByTypeAndTargetUUID(Patient.class.getTypeName(), patientUuid))
+                .thenReturn(Optional.empty());
+
+        List<Slot> result = ipdScheduleService.getMedicationSlots(patientUuid, ServiceType.MEDICATION_REQUEST, forDate);
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.isEmpty());
+        Mockito.verify(slotService, Mockito.never())
+                .getSlotsBySubjectReferenceIdAndForDateAndServiceType(Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    public void shouldReturnSlotsWhenReferenceExistsForGetMedicationSlotsByDate() {
+        String patientUuid = "patient-uuid-1";
+        LocalDate forDate = LocalDate.now();
+        Concept concept = new Concept();
+        Reference reference = new Reference(Patient.class.getTypeName(), patientUuid);
+        List<Slot> expectedSlots = Arrays.asList(new Slot(), new Slot());
+
+        Mockito.when(conceptService.getConceptByName(ServiceType.MEDICATION_REQUEST.conceptName())).thenReturn(concept);
+        Mockito.when(referenceService.getReferenceByTypeAndTargetUUID(Patient.class.getTypeName(), patientUuid))
+                .thenReturn(Optional.of(reference));
+        Mockito.when(slotService.getSlotsBySubjectReferenceIdAndForDateAndServiceType(reference, forDate, concept))
+                .thenReturn(expectedSlots);
+
+        List<Slot> result = ipdScheduleService.getMedicationSlots(patientUuid, ServiceType.MEDICATION_REQUEST, forDate);
+
+        Assert.assertEquals(2, result.size());
+        Mockito.verify(slotService, Mockito.times(1))
+                .getSlotsBySubjectReferenceIdAndForDateAndServiceType(reference, forDate, concept);
+    }
+
+    // -------- getMedicationSlots(patientUuid, serviceType) --------
+
+    @Test
+    public void shouldReturnEmptyListWhenReferenceNotFoundForGetMedicationSlots() {
+        String patientUuid = "patient-uuid-1";
+        Concept concept = new Concept();
+
+        Mockito.when(conceptService.getConceptByName(ServiceType.MEDICATION_REQUEST.conceptName())).thenReturn(concept);
+        Mockito.when(referenceService.getReferenceByTypeAndTargetUUID(Patient.class.getTypeName(), patientUuid))
+                .thenReturn(Optional.empty());
+
+        List<Slot> result = ipdScheduleService.getMedicationSlots(patientUuid, ServiceType.MEDICATION_REQUEST);
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.isEmpty());
+        Mockito.verify(slotService, Mockito.never())
+                .getSlotsBySubjectReferenceIdAndServiceType(Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    public void shouldReturnSlotsWhenReferenceExistsForGetMedicationSlots() {
+        String patientUuid = "patient-uuid-1";
+        Concept concept = new Concept();
+        Reference reference = new Reference(Patient.class.getTypeName(), patientUuid);
+        List<Slot> expectedSlots = Collections.singletonList(new Slot());
+
+        Mockito.when(conceptService.getConceptByName(ServiceType.MEDICATION_REQUEST.conceptName())).thenReturn(concept);
+        Mockito.when(referenceService.getReferenceByTypeAndTargetUUID(Patient.class.getTypeName(), patientUuid))
+                .thenReturn(Optional.of(reference));
+        Mockito.when(slotService.getSlotsBySubjectReferenceIdAndServiceType(reference, concept))
+                .thenReturn(expectedSlots);
+
+        List<Slot> result = ipdScheduleService.getMedicationSlots(patientUuid, ServiceType.MEDICATION_REQUEST);
+
+        Assert.assertEquals(1, result.size());
+        Mockito.verify(slotService, Mockito.times(1)).getSlotsBySubjectReferenceIdAndServiceType(reference, concept);
+    }
+
+    // -------- getMedicationSlots(patientUuid, serviceType, orderUuids) --------
+
+    @Test
+    public void shouldReturnEmptyListWhenReferenceNotFoundForGetMedicationSlotsByOrderUuids() {
+        String patientUuid = "patient-uuid-1";
+        List<String> orderUuids = Arrays.asList("order-uuid-1", "order-uuid-2");
+        Concept concept = new Concept();
+
+        Mockito.when(conceptService.getConceptByName(ServiceType.MEDICATION_REQUEST.conceptName())).thenReturn(concept);
+        Mockito.when(referenceService.getReferenceByTypeAndTargetUUID(Patient.class.getTypeName(), patientUuid))
+                .thenReturn(Optional.empty());
+
+        List<Slot> result = ipdScheduleService.getMedicationSlots(patientUuid, ServiceType.MEDICATION_REQUEST, orderUuids);
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.isEmpty());
+        Mockito.verify(slotService, Mockito.never())
+                .getSlotsBySubjectReferenceIdAndServiceTypeAndOrderUuids(Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    public void shouldReturnSlotsWhenReferenceExistsForGetMedicationSlotsByOrderUuids() {
+        String patientUuid = "patient-uuid-1";
+        List<String> orderUuids = Arrays.asList("order-uuid-1");
+        Concept concept = new Concept();
+        Reference reference = new Reference(Patient.class.getTypeName(), patientUuid);
+        List<Slot> expectedSlots = Arrays.asList(new Slot(), new Slot(), new Slot());
+
+        Mockito.when(conceptService.getConceptByName(ServiceType.MEDICATION_REQUEST.conceptName())).thenReturn(concept);
+        Mockito.when(referenceService.getReferenceByTypeAndTargetUUID(Patient.class.getTypeName(), patientUuid))
+                .thenReturn(Optional.of(reference));
+        Mockito.when(slotService.getSlotsBySubjectReferenceIdAndServiceTypeAndOrderUuids(reference, concept, orderUuids))
+                .thenReturn(expectedSlots);
+
+        List<Slot> result = ipdScheduleService.getMedicationSlots(patientUuid, ServiceType.MEDICATION_REQUEST, orderUuids);
+
+        Assert.assertEquals(3, result.size());
+        Mockito.verify(slotService, Mockito.times(1))
+                .getSlotsBySubjectReferenceIdAndServiceTypeAndOrderUuids(reference, concept, orderUuids);
+    }
+
+    // -------- getMedicationSlotsForTheGivenTimeFrame --------
+
+    @Test
+    public void shouldReturnEmptyListWhenReferenceNotFoundForTimeFrame() {
+        String patientUuid = "patient-uuid-1";
+        LocalDateTime startTime = LocalDateTime.now();
+        LocalDateTime endTime = startTime.plusHours(8);
+        Visit visit = new Visit(1);
+
+        Mockito.when(referenceService.getReferenceByTypeAndTargetUUID(Patient.class.getTypeName(), patientUuid))
+                .thenReturn(Optional.empty());
+
+        List<Slot> result = ipdScheduleService.getMedicationSlotsForTheGivenTimeFrame(
+                patientUuid, startTime, endTime, false, visit);
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.isEmpty());
+        Mockito.verify(slotService, Mockito.never())
+                .getSlotsBySubjectReferenceIdAndForTheGivenTimeFrame(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+        Mockito.verify(slotService, Mockito.never())
+                .getSlotsBySubjectReferenceIncludingAdministeredTimeFrame(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    public void shouldUseAdministeredTimeFrameQueryWhenConsiderAdministeredTimeIsTrue() {
+        String patientUuid = "patient-uuid-1";
+        LocalDateTime startTime = LocalDateTime.now();
+        LocalDateTime endTime = startTime.plusHours(8);
+        Visit visit = new Visit(1);
+        Reference reference = new Reference(Patient.class.getTypeName(), patientUuid);
+        List<Slot> expectedSlots = Arrays.asList(new Slot());
+
+        Mockito.when(referenceService.getReferenceByTypeAndTargetUUID(Patient.class.getTypeName(), patientUuid))
+                .thenReturn(Optional.of(reference));
+        Mockito.when(slotService.getSlotsBySubjectReferenceIncludingAdministeredTimeFrame(reference, startTime, endTime, visit))
+                .thenReturn(expectedSlots);
+
+        List<Slot> result = ipdScheduleService.getMedicationSlotsForTheGivenTimeFrame(
+                patientUuid, startTime, endTime, true, visit);
+
+        Assert.assertEquals(1, result.size());
+        Mockito.verify(slotService, Mockito.times(1))
+                .getSlotsBySubjectReferenceIncludingAdministeredTimeFrame(reference, startTime, endTime, visit);
+        Mockito.verify(slotService, Mockito.never())
+                .getSlotsBySubjectReferenceIdAndForTheGivenTimeFrame(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    public void shouldUseScheduledTimeFrameQueryWhenConsiderAdministeredTimeIsFalse() {
+        String patientUuid = "patient-uuid-1";
+        LocalDateTime startTime = LocalDateTime.now();
+        LocalDateTime endTime = startTime.plusHours(8);
+        Visit visit = new Visit(1);
+        Reference reference = new Reference(Patient.class.getTypeName(), patientUuid);
+        List<Slot> expectedSlots = Arrays.asList(new Slot(), new Slot());
+
+        Mockito.when(referenceService.getReferenceByTypeAndTargetUUID(Patient.class.getTypeName(), patientUuid))
+                .thenReturn(Optional.of(reference));
+        Mockito.when(slotService.getSlotsBySubjectReferenceIdAndForTheGivenTimeFrame(reference, startTime, endTime, visit))
+                .thenReturn(expectedSlots);
+
+        List<Slot> result = ipdScheduleService.getMedicationSlotsForTheGivenTimeFrame(
+                patientUuid, startTime, endTime, false, visit);
+
+        Assert.assertEquals(2, result.size());
+        Mockito.verify(slotService, Mockito.times(1))
+                .getSlotsBySubjectReferenceIdAndForTheGivenTimeFrame(reference, startTime, endTime, visit);
+        Mockito.verify(slotService, Mockito.never())
+                .getSlotsBySubjectReferenceIncludingAdministeredTimeFrame(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+    }
+}

--- a/omod/src/test/java/org/openmrs/module/ipd/web/service/impl/IPDWardServiceImplTest.java
+++ b/omod/src/test/java/org/openmrs/module/ipd/web/service/impl/IPDWardServiceImplTest.java
@@ -1,0 +1,226 @@
+package org.openmrs.module.ipd.web.service.impl;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openmrs.module.bedmanagement.entity.Bed;
+import org.openmrs.module.bedmanagement.entity.BedPatientAssignment;
+import org.openmrs.module.ipd.api.model.AdmittedPatient;
+import org.openmrs.module.ipd.api.model.IPDPatientDetails;
+import org.openmrs.module.ipd.api.model.WardPatientsSummary;
+import org.openmrs.module.ipd.api.service.WardService;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IPDWardServiceImplTest {
+
+    @InjectMocks
+    private IPDWardServiceImpl ipdWardService;
+
+    @Mock
+    private WardService wardService;
+
+    // -------- getIPDWardPatientSummary --------
+
+    @Test
+    public void shouldDelegateGetIPDWardPatientSummaryToWardService() {
+        String wardUuid = "ward-uuid-1";
+        String providerUuid = "provider-uuid-1";
+        WardPatientsSummary expected = new WardPatientsSummary(10L, 4L);
+
+        Mockito.when(wardService.getIPDWardPatientSummary(wardUuid, providerUuid)).thenReturn(expected);
+
+        WardPatientsSummary result = ipdWardService.getIPDWardPatientSummary(wardUuid, providerUuid);
+
+        Assert.assertEquals(expected, result);
+        Mockito.verify(wardService, Mockito.times(1)).getIPDWardPatientSummary(wardUuid, providerUuid);
+    }
+
+    // -------- getIPDPatientByWard --------
+
+    @Test
+    public void shouldReturnEmptyDetailsWhenWardServiceReturnsNull() {
+        String wardUuid = "ward-uuid-1";
+
+        Mockito.when(wardService.getWardPatientsByUuid(wardUuid, null)).thenReturn(null);
+
+        IPDPatientDetails result = ipdWardService.getIPDPatientByWard(wardUuid, 0, 10, null);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(0, result.getAdmittedPatients().size());
+        Assert.assertEquals(Integer.valueOf(0), result.getPatientCount());
+    }
+
+    @Test
+    public void shouldReturnEmptyDetailsWhenWardServiceReturnsEmptyList() {
+        String wardUuid = "ward-uuid-1";
+
+        Mockito.when(wardService.getWardPatientsByUuid(wardUuid, null)).thenReturn(Collections.emptyList());
+
+        IPDPatientDetails result = ipdWardService.getIPDPatientByWard(wardUuid, 0, 10, null);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(0, result.getAdmittedPatients().size());
+        Assert.assertEquals(Integer.valueOf(0), result.getPatientCount());
+    }
+
+    @Test
+    public void shouldApplyPaginationWithOffsetAndLimit() {
+        String wardUuid = "ward-uuid-1";
+        List<AdmittedPatient> patients = Arrays.asList(
+                createAdmittedPatient("1"),
+                createAdmittedPatient("2"),
+                createAdmittedPatient("3"),
+                createAdmittedPatient("4"),
+                createAdmittedPatient("5")
+        );
+
+        Mockito.when(wardService.getWardPatientsByUuid(wardUuid, null)).thenReturn(patients);
+
+        IPDPatientDetails result = ipdWardService.getIPDPatientByWard(wardUuid, 1, 2, null);
+
+        Assert.assertEquals(2, result.getAdmittedPatients().size());
+        Assert.assertEquals(Integer.valueOf(5), result.getPatientCount());
+    }
+
+    @Test
+    public void shouldClampOffsetToListSizeWhenOffsetExceedsTotalCount() {
+        String wardUuid = "ward-uuid-1";
+        List<AdmittedPatient> patients = Arrays.asList(
+                createAdmittedPatient("1"),
+                createAdmittedPatient("2")
+        );
+
+        Mockito.when(wardService.getWardPatientsByUuid(wardUuid, null)).thenReturn(patients);
+
+        IPDPatientDetails result = ipdWardService.getIPDPatientByWard(wardUuid, 10, 5, null);
+
+        Assert.assertEquals(0, result.getAdmittedPatients().size());
+        Assert.assertEquals(Integer.valueOf(2), result.getPatientCount());
+    }
+
+    @Test
+    public void shouldSortByBedNumberNumericallyWhenSortByIsBedNumber() {
+        String wardUuid = "ward-uuid-1";
+        List<AdmittedPatient> patients = Arrays.asList(
+                createAdmittedPatient("10"),
+                createAdmittedPatient("2"),
+                createAdmittedPatient("1"),
+                createAdmittedPatient("20")
+        );
+
+        Mockito.when(wardService.getWardPatientsByUuid(wardUuid, "bedNumber")).thenReturn(patients);
+
+        IPDPatientDetails result = ipdWardService.getIPDPatientByWard(wardUuid, 0, 4, "bedNumber");
+
+        Assert.assertEquals(4, result.getAdmittedPatients().size());
+        Assert.assertEquals("1", result.getAdmittedPatients().get(0).getBedPatientAssignment().getBed().getBedNumber());
+        Assert.assertEquals("2", result.getAdmittedPatients().get(1).getBedPatientAssignment().getBed().getBedNumber());
+        Assert.assertEquals("10", result.getAdmittedPatients().get(2).getBedPatientAssignment().getBed().getBedNumber());
+        Assert.assertEquals("20", result.getAdmittedPatients().get(3).getBedPatientAssignment().getBed().getBedNumber());
+    }
+
+    @Test
+    public void shouldNotApplyNumericSortWhenBedNumbersContainNonNumericValues() {
+        String wardUuid = "ward-uuid-1";
+        List<AdmittedPatient> patients = Arrays.asList(
+                createAdmittedPatient("B10"),
+                createAdmittedPatient("A2"),
+                createAdmittedPatient("1")
+        );
+
+        Mockito.when(wardService.getWardPatientsByUuid(wardUuid, "bedNumber")).thenReturn(patients);
+
+        IPDPatientDetails result = ipdWardService.getIPDPatientByWard(wardUuid, 0, 3, "bedNumber");
+
+        Assert.assertEquals(3, result.getAdmittedPatients().size());
+        // Order unchanged when not all-numeric
+        Assert.assertEquals("B10", result.getAdmittedPatients().get(0).getBedPatientAssignment().getBed().getBedNumber());
+    }
+
+    // -------- getIPDPatientsByWardAndProvider --------
+
+    @Test
+    public void shouldReturnEmptyDetailsWhenProviderPatientListIsNull() {
+        String wardUuid = "ward-uuid-1";
+        String providerUuid = "provider-uuid-1";
+
+        Mockito.when(wardService.getPatientsByWardAndProvider(wardUuid, providerUuid, null)).thenReturn(null);
+
+        IPDPatientDetails result = ipdWardService.getIPDPatientsByWardAndProvider(wardUuid, providerUuid, 0, 10, null);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(0, result.getAdmittedPatients().size());
+        Assert.assertEquals(Integer.valueOf(0), result.getPatientCount());
+    }
+
+    @Test
+    public void shouldApplyPaginationForPatientsByWardAndProvider() {
+        String wardUuid = "ward-uuid-1";
+        String providerUuid = "provider-uuid-1";
+        List<AdmittedPatient> patients = Arrays.asList(
+                createAdmittedPatient("1"),
+                createAdmittedPatient("2"),
+                createAdmittedPatient("3")
+        );
+
+        Mockito.when(wardService.getPatientsByWardAndProvider(wardUuid, providerUuid, null)).thenReturn(patients);
+
+        IPDPatientDetails result = ipdWardService.getIPDPatientsByWardAndProvider(wardUuid, providerUuid, 0, 2, null);
+
+        Assert.assertEquals(2, result.getAdmittedPatients().size());
+        Assert.assertEquals(Integer.valueOf(3), result.getPatientCount());
+    }
+
+    // -------- searchIPDPatientsInWard --------
+
+    @Test
+    public void shouldReturnEmptyDetailsWhenSearchReturnsNull() {
+        String wardUuid = "ward-uuid-1";
+        List<String> searchKeys = Arrays.asList("bedNumber");
+
+        Mockito.when(wardService.searchWardPatients(wardUuid, searchKeys, "5", null)).thenReturn(null);
+
+        IPDPatientDetails result = ipdWardService.searchIPDPatientsInWard(wardUuid, searchKeys, "5", 0, 10, null);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(0, result.getAdmittedPatients().size());
+        Assert.assertEquals(Integer.valueOf(0), result.getPatientCount());
+    }
+
+    @Test
+    public void shouldApplyPaginationForSearchResults() {
+        String wardUuid = "ward-uuid-1";
+        List<String> searchKeys = Arrays.asList("patientName");
+        List<AdmittedPatient> patients = Arrays.asList(
+                createAdmittedPatient("5"),
+                createAdmittedPatient("6"),
+                createAdmittedPatient("7"),
+                createAdmittedPatient("8")
+        );
+
+        Mockito.when(wardService.searchWardPatients(wardUuid, searchKeys, "John", null)).thenReturn(patients);
+
+        IPDPatientDetails result = ipdWardService.searchIPDPatientsInWard(wardUuid, searchKeys, "John", 1, 2, null);
+
+        Assert.assertEquals(2, result.getAdmittedPatients().size());
+        Assert.assertEquals(Integer.valueOf(4), result.getPatientCount());
+    }
+
+    private AdmittedPatient createAdmittedPatient(String bedNumber) {
+        Bed bed = Mockito.mock(Bed.class);
+        Mockito.when(bed.getBedNumber()).thenReturn(bedNumber);
+
+        BedPatientAssignment assignment = Mockito.mock(BedPatientAssignment.class);
+        Mockito.when(assignment.getBed()).thenReturn(bed);
+
+        return new AdmittedPatient(assignment, 0L, null);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
 	</modules>
 
 	<properties>
-		<openmrsPlatformVersion>2.5.12</openmrsPlatformVersion>
-		<openMRSWebServicesVersion>2.44.0</openMRSWebServicesVersion>
+		<openmrsPlatformVersion>2.6.15</openmrsPlatformVersion>
+		<openMRSWebServicesVersion>2.50.0</openMRSWebServicesVersion>
 		<bedManagementVersion>6.0.0</bedManagementVersion>
 		<springVersion>5.2.14.RELEASE</springVersion>
 		<junitVersion>4.13</junitVersion>
@@ -47,11 +47,11 @@
 		<argLine>-Xmx1024m</argLine>
 		<jacocoVersion>0.7.9</jacocoVersion>
 		<lombokVersion>1.18.26</lombokVersion>
-		<openmrsFhir2Version>2.1.0</openmrsFhir2Version>
-		<fhir2ExtensionVersion>1.3.0</fhir2ExtensionVersion>
-		<bahmniVersion>1.2.0</bahmniVersion>
-		<emrapi-omod.version>1.36.0</emrapi-omod.version>
-		<medicationAdminstrationVersion>1.0.0</medicationAdminstrationVersion>
+		<openmrsFhir2Version>2.5.0</openmrsFhir2Version>
+		<fhir2ExtensionVersion>2.0.0-SNAPSHOT</fhir2ExtensionVersion>
+		<bahmniVersion>2.0.0-SNAPSHOT</bahmniVersion>
+		<emrapi-omod.version>2.3.0</emrapi-omod.version>
+		<medicationAdminstrationVersion>2.0.0-SNAPSHOT</medicationAdminstrationVersion>
 	</properties>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
 			</dependency>
 			<dependency>
 				<groupId>org.openmrs.module</groupId>
-				<artifactId>webservices.rest-omod-2.0</artifactId>
+				<artifactId>webservices.rest-omod</artifactId>
 				<version>${openMRSWebServicesVersion}</version>
 				<scope>provided</scope>
 			</dependency>


### PR DESCRIPTION
Replace JPA annotations with Hibernate XML mappings (`hbm.xml` files) for all three entity classes: `MedicationAdministration`, `MedicationAdministrationPerformer`, and `MedicationAdministrationNote`.

The `@Entity`, `@Table`, `@Column`, `@JoinColumn`, `@ManyToOne`, `@OneToMany`, `@Enumerated`, `@Id`, and `@GeneratedValue` annotations are removed from the Java classes. The equivalent mapping information is expressed in `.hbm.xml` files instead.

These mapping files are registered through the `<mappingFiles>` element in the module's `config.xml`. This tells the OpenMRS module framework to add them directly to the Hibernate `SessionFactory` configuration — bypassing the annotation processor entirely. The entities go straight into Hibernate's mapping metadata through the XML pathway, which has no issues with the `BaseFormRecordableOpenmrsData` superclass.